### PR TITLE
Fix dom.t to handle weakrefs (HTML-Tree 5)

### DIFF
--- a/t/dom.t
+++ b/t/dom.t
@@ -60,7 +60,7 @@ is $div2->firstChild, "\n        ", "firstChild works";
 is $div2->lastChild, "\n    ", "lastChild works";
 
 $dom = pQuery::DOM->fromHTML('<div>xxx<!-- yyy -->zzz</div>');
-my @elems = pQuery::DOM->fromHTML('<div>xxx<!-- yyy -->zzz</div>')->childNodes;
+my @elems = $dom->childNodes;
 my $comment = $elems[1];
 is $comment->nodeType, 8, 'Handle comment nodes';
 is $comment->nodeValue, ' yyy ', 'Handle comment node value';


### PR DESCRIPTION
With the new version of HTML-Tree (test release 4.900 is out now), `parentNode` becomes undef if there's no other reference to the parent or its ancestors
