### PR TITLE
Fixed issue with $document bening an array ref not an object

### DIFF
--- a/lib/pQuery.pm
+++ b/lib/pQuery.pm
@@ -80,7 +80,7 @@ sub _init {
 #                 $selector = $this->_clean([$1], $context);
             }
             else {
-                my $elem = $document->getElementById($3);
+                my ($elem) = map {$_->getElementById($3)} grep {ref $_} @$document;
                 if ($elem) {
                     @$this = $elem;
                     return $this;


### PR DESCRIPTION
The $document appears as if it is meant to be an array ref but on this line is us used as a object, the fix is a best guess at what is meant to happen.
